### PR TITLE
Add fundamentus scraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # Investra
 Investra is an AI-powered platform that analyzes markets, predicts trends, and optimizes investment decisions in real time.
+
+## Fundamentus scraper
+
+This repository contains a small utility named `fundamentus_scraper.py` that
+collects some basic indicators from
+[`fundamentus.com.br`](https://www.fundamentus.com.br/). The script fetches the
+data for a specific ticker (by default `BBDC4`) and prints the values separated
+by semicolons.
+
+### Running
+
+```bash
+python fundamentus_scraper.py
+```
+
+The result will look similar to:
+
+```
+BBDC4;12.34;08/07/2024;10.50;14.80;8.50;1.20;2.50
+```
+
+The script relies only on the Python standard library. It requires internet
+access to retrieve the HTML page from fundamentus.com.br.

--- a/fundamentus_scraper.py
+++ b/fundamentus_scraper.py
@@ -1,0 +1,67 @@
+import re
+from urllib.request import urlopen
+
+def strip_tags(text: str) -> str:
+    """Remove HTML tags and leading/trailing whitespace."""
+    return re.sub(r'<[^>]+>', '', text).strip()
+
+
+def fetch_fundamentals(papel: str) -> dict:
+    """Fetch basic fundamentals from fundamentus.com.br for a given ticker.
+
+    The returned dictionary contains textual values for:
+    Papel, Cotacao, Data ult cot, Min 52 sem, Max 52 sem, P/L, LPA and VPA.
+    """
+    url = f"https://www.fundamentus.com.br/detalhes.php?papel={papel}"
+    with urlopen(url) as resp:
+        html = resp.read().decode('latin1')
+
+    # generic regex for <td>label</td><td>value</td>
+    pattern = re.compile(r'<td[^>]*>\s*([^<]*?)\s*</td>\s*<td[^>]*>(.*?)</td>', re.S)
+
+    data = {}
+    labels = {
+        'Papel': 'Papel',
+        'Cotação': 'Cotacao',
+        'Data últ cot': 'Data ult cot',
+        'Min 52 sem': 'Min 52 sem',
+        'Max 52 sem': 'Max 52 sem',
+        'P/L': 'P/L',
+        'LPA': 'LPA',
+        'VPA': 'VPA',
+    }
+
+    for label, value in pattern.findall(html):
+        clean_label = strip_tags(label)
+        clean_value = strip_tags(value)
+        if clean_label in labels:
+            data[labels[clean_label]] = clean_value
+
+    return data
+
+
+def main():
+    papel = 'BBDC4'
+    try:
+        data = fetch_fundamentals(papel)
+    except Exception as exc:
+        print(f"Erro ao buscar dados: {exc}")
+        return
+
+    ordered_keys = [
+        'Papel',
+        'Cotacao',
+        'Data ult cot',
+        'Min 52 sem',
+        'Max 52 sem',
+        'P/L',
+        'LPA',
+        'VPA',
+    ]
+
+    values = [data.get(k, '') for k in ordered_keys]
+    print(';'.join(values))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add a Python utility to fetch data from fundamentus.com.br
- document how to run the script

## Testing
- `python fundamentus_scraper.py` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68711df96fa48322813e439f9a0ba636