### PR TITLE
Add Docker installer script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY fundamentus_scraper.py /app/
+CMD ["python", "/app/fundamentus_scraper.py"]

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# This script installs Docker on Amazon Linux and runs the fundamentus scraper
+# inside a container.
+
+set -euo pipefail
+
+# Install Docker
+sudo yum update -y
+sudo amazon-linux-extras install docker -y || sudo yum install -y docker
+sudo service docker start
+sudo usermod -a -G docker $USER
+
+# Build the Docker image
+sudo docker build -t fundamentus-scraper .
+
+# Run the scraper
+sudo docker run --rm fundamentus-scraper


### PR DESCRIPTION
## Summary
- create `Dockerfile` to run `fundamentus_scraper.py`
- add `install.sh` to set up Docker on Amazon Linux and execute the script

## Testing
- `bash -n install.sh`
- `python fundamentus_scraper.py` *(fails: Tunnel connection failed)*
- `docker build -t fundamentus-scraper .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68711f79407c8322b5b9846119038017